### PR TITLE
add `wait-for-postgres.js` script

### DIFF
--- a/infra/scripts/wait-for-postgres.js
+++ b/infra/scripts/wait-for-postgres.js
@@ -1,0 +1,19 @@
+const { exec } = require("node:child_process");
+
+function checkPostgres() {
+  exec("docker exec database pg_isready --host localhost", handleReturn);
+
+  function handleReturn(error, stdout) {
+    if (stdout.search("accepting connections") === -1) {
+      process.stdout.write(".");
+      checkPostgres();
+      return;
+    }
+
+    console.log("\n🟢 Postgres está pronto e aceitando conexões");
+  }
+}
+
+process.stdout.write("\n\n🔴 Aguardando Postgres aceitar conexões");
+
+checkPostgres();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Clone do https://tabnews.com para o curso.dev",
   "main": "index.js",
   "scripts": {
-    "dev": "npm run service:up && next dev",
+    "dev": "npm run service:up && npm run wait-for-postgres && npm run migration:up && next dev",
     "lint:check": "prettier --check .",
     "lint:fix": "prettier --write . ",
     "test": "jest --runInBand",
@@ -13,7 +13,8 @@
     "service:down": "docker compose -f ./infra/compose.yaml down",
     "service:stop": "docker compose -f ./infra/compose.yaml stop",
     "migration:create": "node-pg-migrate -m infra/migrations create",
-    "migration:up": "node-pg-migrate -m infra/migrations --envPath .env.development up"
+    "migration:up": "node-pg-migrate -m infra/migrations --envPath .env.development up",
+    "wait-for-postgres": "node infra/scripts/wait-for-postgres.js"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
Estabiliza o `npm run dev` para que todas as dependencias e migrations possam ser executadas